### PR TITLE
Nullable keys

### DIFF
--- a/src/config/parsing/README.md
+++ b/src/config/parsing/README.md
@@ -76,3 +76,6 @@ Basic checks:
     3. Are any keys present multiple times?
     4. Are any values completely whitespace characters surrounded by quote marks?
     5. Do any values have special characters? (Any of these: !#$%&()*;<>?@[]^`{|}~ )
+    
+For values found in the 'NULLABLE_KEYS' list in 'src/config/util/nullable_keys.py', these values are
+  allowed to be empty. If they are, these basic checks are not done 

--- a/src/config/parsing/parser.py
+++ b/src/config/parsing/parser.py
@@ -151,7 +151,7 @@ class Parser:
         keys_list = [k for k, v in key_value_pairs]
 
         for key, value in key_value_pairs:
-            if key in NULLABLE_KEYS and value == "":
+            if key in NULLABLE_KEYS and (value == "" or value == '""'):
                 # These keys are allowed to have empty values, do not perform checking (simply write a debug message)
                 self.project_logger.log_debug(
                     "The key '" + key + "' had an empty value; since its value is optional, no error was thrown"

--- a/src/config/parsing/parser.py
+++ b/src/config/parsing/parser.py
@@ -17,6 +17,7 @@ import logging
 import sys
 from src.config.util.util import read_json_file
 from src.config.util.log import ProjectLogger
+from src.config.util.nullable_keys import NULLABLE_KEYS
 
 """
 Exit code Rules:
@@ -137,6 +138,8 @@ class Parser:
         """
          Takes in a list of (Key, Value) tuples, and confirms that they are valid (or throws an error)
 
+        Keys that are allowed to be empty are not checked (see src/config/util/nullable_keys.py)
+
          Checks performed:
             1. Verifies that all Keys have an associated Value
             2. Verifies that the Value is enclosed in double quotes
@@ -148,47 +151,53 @@ class Parser:
         keys_list = [k for k, v in key_value_pairs]
 
         for key, value in key_value_pairs:
-            # Check that the value is not empty
-            if value == '':
-                self.project_logger.log_error(
-                    "E.par.NVa.1",
-                    "No value present for key '" + key + "' in input file '" + file_path + "'"
+            if key in NULLABLE_KEYS and value == "":
+                # These keys are allowed to have empty values, do not perform checking (simply write a debug message)
+                self.project_logger.log_debug(
+                    "The key '" + key + "' had an empty value; since its value is optional, no error was thrown"
                 )
-                sys.exit(1)
-            # Check that the value is enclosed in double quotes
-            elif value[0] != '"' or value[-1] != '"':
-                self.project_logger.log_error(
-                    "E.par.NQt.1",
-                    "No quotes around the value for key '" + key + "' in input file '" + file_path + "'"
-                )
-                sys.exit(1)
-            # Check to see that non-whitespace are present between the quote marks
-            #   value[1:-1] trims off the first and last chars and strip removes all whitespace characters from the ends
-            elif value[1:-1].strip() == '':
-                self.project_logger.log_error(
-                    "E.par.WhS.1",
-                    "Only whitespace found in value '" + value + "' of key '" + key + "' in input file '" +
-                    file_path + "'"
-                )
-                sys.exit(1)
-            # Check if any special characters are present
-            special_chars = "!#$%&()*;<>?@[]^`{|}~"
-            for special_char in special_chars:
-                if special_char in value:
+            else:
+                # Check that the value is not empty
+                if value == '':
                     self.project_logger.log_error(
-                        "E.par.SpC.1",
-                        "Invalid special character '" + special_char + "' found in value '" + value +
-                        "' of key '" + key + "' in input file '" + file_path + "'"
+                        "E.par.NVa.1",
+                        "No value present for key '" + key + "' in input file '" + file_path + "'"
                     )
                     sys.exit(1)
-            # Check whether any key is present multiple times
-            if keys_list.count(key) > 1:
-                self.project_logger.log_error(
-                    "E.par.Key.1", "Key '" + key + "' is present more than once in input file '" + file_path + "'"
-                )
-                sys.exit(1)
-            else:
-                self.project_logger.log_debug("The key-value pair '" + key + "=" + value + "' is a valid pair")
+                # Check that the value is enclosed in double quotes
+                elif value[0] != '"' or value[-1] != '"':
+                    self.project_logger.log_error(
+                        "E.par.NQt.1",
+                        "No quotes around the value for key '" + key + "' in input file '" + file_path + "'"
+                    )
+                    sys.exit(1)
+                # Check to see that non-whitespace are present between the quote marks
+                #   value[1:-1] trims off the first and last chars and strip removes all whitespace chars from the ends
+                elif value[1:-1].strip() == '':
+                    self.project_logger.log_error(
+                        "E.par.WhS.1",
+                        "Only whitespace found in value '" + value + "' of key '" + key + "' in input file '" +
+                        file_path + "'"
+                    )
+                    sys.exit(1)
+                # Check if any special characters are present
+                special_chars = "!#$%&()*;<>?@[]^`{|}~"
+                for special_char in special_chars:
+                    if special_char in value:
+                        self.project_logger.log_error(
+                            "E.par.SpC.1",
+                            "Invalid special character '" + special_char + "' found in value '" + value +
+                            "' of key '" + key + "' in input file '" + file_path + "'"
+                        )
+                        sys.exit(1)
+                # Check whether any key is present multiple times
+                if keys_list.count(key) > 1:
+                    self.project_logger.log_error(
+                        "E.par.Key.1", "Key '" + key + "' is present more than once in input file '" + file_path + "'"
+                    )
+                    sys.exit(1)
+                else:
+                    self.project_logger.log_debug("The key-value pair '" + key + "=" + value + "' is a valid pair")
 
     def handle_special_keys(self, config_key, full_dict_key, output_dictionary, trimmed_value, file_path):
         """
@@ -237,7 +246,6 @@ class Parser:
         elif config_key == "DBSNP":
             output_dictionary[str(full_dict_key) + "Idx"] = str(trimmed_value) + ".idx"
 
-
     def insert_values_into_dict(self, starting_dict, key_value_tuple, file_path):
         """
          Takes an initial dictionary and a list of (Key, Value) tuples.
@@ -269,7 +277,6 @@ class Parser:
                     "Key '" + config_key + "' in config file '" + file_path +
                     "' had no corresponding key in the JSON template; this key-value pair was ignored"
                 )
-
         return output_dict
 
     def fill_in_json_template(self, input_file_list, json_template_file, output_file):

--- a/src/config/parsing/test_parser.py
+++ b/src/config/parsing/test_parser.py
@@ -46,6 +46,11 @@ class TestParsingTools(unittest.TestCase):
         with self.assertRaises(SystemExit):
             self.parser.validate_key_value_pairs(no_value_tuple, file_path="dummy_file_path")
 
+    def test_validate_key_value_pairs_pass_empty_nullable_key(self):
+        # InputRead2 is a key that is allowed to be empty (see src/config/util/nullable_keys.py)
+        nullable_key_empty_value = [("InputRead2", "")]
+        self.parser.validate_key_value_pairs(nullable_key_empty_value, file_path="dummy_file_path")
+
     def test_validate_key_value_pairs_fail_no_quotes(self):
         no_value_tuple = [("keyA", 'Value without quotes')]
         with self.assertRaises(SystemExit):

--- a/src/config/parsing/test_parser.py
+++ b/src/config/parsing/test_parser.py
@@ -51,6 +51,12 @@ class TestParsingTools(unittest.TestCase):
         nullable_key_empty_value = [("InputRead2", "")]
         self.parser.validate_key_value_pairs(nullable_key_empty_value, file_path="dummy_file_path")
 
+    def test_validate_key_value_pairs_fail_empty_non_nullable_key(self):
+        # InputRead1 is a key that is not allowed to be empty (it must have a value)
+        key_empty_value = [("InputRead1", "")]
+        with self.assertRaises(SystemExit):
+            self.parser.validate_key_value_pairs(key_empty_value, file_path="dummy_file_path")
+
     def test_validate_key_value_pairs_fail_no_quotes(self):
         no_value_tuple = [("keyA", 'Value without quotes')]
         with self.assertRaises(SystemExit):

--- a/src/config/parsing/test_resources/test_input.config
+++ b/src/config/parsing/test_resources/test_input.config
@@ -6,7 +6,7 @@ REF="ref.fa"
 DBSNP="dbsnp.vcf"
 LICENSE="License.lic"
 # This value is allowed to be empty; the parser should not check its value
-InputRead2=
+DebugMode=
 
 # Comment line should be removed
 # Along with the blank line above

--- a/src/config/parsing/test_resources/test_input.config
+++ b/src/config/parsing/test_resources/test_input.config
@@ -6,7 +6,8 @@ REF="ref.fa"
 DBSNP="dbsnp.vcf"
 LICENSE="License.lic"
 # This value is allowed to be empty; the parser should not check its value
-DebugMode=
+DebugMode=""
+InputRead2=
 
 # Comment line should be removed
 # Along with the blank line above

--- a/src/config/parsing/test_resources/test_input.config
+++ b/src/config/parsing/test_resources/test_input.config
@@ -5,6 +5,8 @@ test_decimal="3.14159"
 REF="ref.fa"
 DBSNP="dbsnp.vcf"
 LICENSE="License.lic"
+# This value is allowed to be empty; the parser should not check its value
+InputRead2=
 
 # Comment line should be removed
 # Along with the blank line above

--- a/src/config/parsing/test_resources/test_output.json
+++ b/src/config/parsing/test_resources/test_output.json
@@ -7,5 +7,7 @@
     "major.minor.DBSNP": "dbsnp.vcf",
     "major.minor1.LICENSE": "License.lic",
     "major.minor2.LICENSE": "License.lic",
+    "major.minor.DebugMode": "",
+    "major.minor.InputRead2": "",
     "major.minor.DBSNPIdx": "dbsnp.vcf.idx"
 }

--- a/src/config/parsing/test_resources/test_output_template.json
+++ b/src/config/parsing/test_resources/test_output_template.json
@@ -7,5 +7,5 @@
   "major.minor.DBSNP": "String",
   "major.minor1.LICENSE": "String",
   "major.minor2.LICENSE": "String",
-  "major.minor.InputRead2": "String"
+  "major.minor.DebugMode": "String"
 }

--- a/src/config/parsing/test_resources/test_output_template.json
+++ b/src/config/parsing/test_resources/test_output_template.json
@@ -6,5 +6,6 @@
   "major.minor.REF": "String",
   "major.minor.DBSNP": "String",
   "major.minor1.LICENSE": "String",
-  "major.minor2.LICENSE": "String"
+  "major.minor2.LICENSE": "String",
+  "major.minor.InputRead2": "String"
 }

--- a/src/config/parsing/test_resources/test_output_template.json
+++ b/src/config/parsing/test_resources/test_output_template.json
@@ -7,5 +7,6 @@
   "major.minor.DBSNP": "String",
   "major.minor1.LICENSE": "String",
   "major.minor2.LICENSE": "String",
-  "major.minor.DebugMode": "String"
+  "major.minor.DebugMode": "String",
+  "major.minor.InputRead2": "String"
 }

--- a/src/config/util/nullable_keys.py
+++ b/src/config/util/nullable_keys.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 
-# This is the list of keys that are allowed to be blank in the flat config file
+# This is the list of keys that are allowed to be blank (i.e. they are "nullable") in the flat config file
 NULLABLE_KEYS = ("DebugMode", "InputRead2")

--- a/src/config/util/nullable_keys.py
+++ b/src/config/util/nullable_keys.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+
+# This is the list of keys that are allowed to be blank in the flat config file
+NULLABLE_KEYS = ("DebugMode", "InputRead2")

--- a/src/config/util/test_util.py
+++ b/src/config/util/test_util.py
@@ -15,7 +15,7 @@ class TestUtil(unittest.TestCase):
 
     # Turn the project logger off during UnitTesting, so the end user is not confused by error messages
     #   (Some tests are designed to fail, so they will log "ERROR" messages that are expected)
-    project_logger.disabled = True
+    project_logger.logger.disabled = True
 
     def test_read_json_file(self):
         expected_key_types_dict = {"key_1": "Value_1", "key_2": "Value_2", "key_3": "Value_3"}

--- a/src/config/validation/README.md
+++ b/src/config/validation/README.md
@@ -96,6 +96,11 @@ executable means that the user can move into the directory.
        
 This type should only be used for directories that only need to be read.
 
+#### DebugMode
+
+This is a special case. The variable 'DebugMode' has only one acceptable value: '-d'.
+  This value is passed directly to the bash scripts, and passing any other value (other
+  than an empty value) will kill the script.
 
 # IMPORTANT NOTE!
 

--- a/src/config/validation/key_types.json
+++ b/src/config/validation/key_types.json
@@ -27,6 +27,6 @@
   "Adapters": "File",
   "RefAmb": "File",
   "SampleName": "String",
-  "DebugMode": "String",
+  "DebugMode": "DebugMode",
   "SentieonLicense": "String"
 }

--- a/src/config/validation/key_validation.py
+++ b/src/config/validation/key_validation.py
@@ -197,16 +197,6 @@ class Validator:
         def make_message(message):
             return 'Input variable "' + key_name + '" points to "' + key_value + '", which ' + message
 
-        # For all variables, if the value is set to NULL, give an info message and stop the validation for that key
-        #   This is necessary because some variables are optional, and NULL is a way to signal to Cromwell/WDL that
-        #   nothing was entered
-        if key_value.lower() == 'null':
-            self.project_logger.log_debug("The key '" + key_name + "' was set to '" + key_value +
-                                          "'; its type will not be validated "
-                                          )
-            # Stop the function here; do not try to validate this key
-            return True
-
         # Directory ###
         if lowered_key_type in ("directory", "dir"):
             # Checks if the directory exists, and does not check permissions
@@ -217,7 +207,7 @@ class Validator:
                 return True
 
         # Output Directory ###
-        if lowered_key_type in ("output_directory", "output_dir", "outputdir", "outputdirectory", "output directory"):
+        elif lowered_key_type in ("output_directory", "output_dir", "outputdir", "outputdirectory", "output directory"):
             # Checks if the directory exists, and has executable (ability to traverse into), read (read contents),
             #   and write (permission to create contents in) permissions
             if not self.__directory_exists(key_value):

--- a/src/config/validation/key_validation.py
+++ b/src/config/validation/key_validation.py
@@ -47,6 +47,8 @@ E.val.Boo.1 = A value expected to be a boolean type was not
 E.val.Int.1 = A value expected to be an integer was not
 E.val.Dec.1 = A value expected to be a Decimal (float or double) was not
 E.val.UNK.1 = A type listed in the key-types file was not recognized as a valid type
+
+E.val.Bug.1 = The DebugMode key had a non-empty value that was not '-d'
 """
 
 

--- a/src/config/validation/key_validation.py
+++ b/src/config/validation/key_validation.py
@@ -332,6 +332,16 @@ class Validator:
             else:
                 self.project_logger.log_error('E.val.Dec.1', make_message('is not a valid number'))
                 return False
+        # DebugMode (special case where the only acceptable value is '-d')
+        elif lowered_key_type == "debugmode":
+            if key_value == "-d":
+                self.project_logger.log_debug(make_message('is the correct debug flag'))
+                return True
+            else:
+                self.project_logger.log_error(
+                    'E.val.Bug.1', make_message("is not valid: DebugMode must be blank or '-d'")
+                )
+                return False
         # Other ###
         # (kill the program if an unknown type is provided in the type file)
         else:

--- a/src/config/validation/key_validation.py
+++ b/src/config/validation/key_validation.py
@@ -11,6 +11,7 @@ import logging
 import pathlib
 from src.config.util.util import read_json_file
 from src.config.util.log import ProjectLogger
+from src.config.util.nullable_keys import NULLABLE_KEYS
 
 """
 Exit code Rules:
@@ -176,11 +177,20 @@ class Validator:
         For a given key, confirm that its value is of the type that is expected; returns True if the key is
             valid and False if it is not
 
-        If a value is validated, print an INFO message stating that X key was validated; return true
+        If a value is validated, print a DEBUG message stating that X key was validated; return true
         If a value is of a type that has no validation defined (such as String), print an INFO message; return true
         If a faulty value is found, print an ERROR message; return false
         """
         lowered_key_type = key_type.lower()
+
+        # If the key has an empty value, and it is in the NULLABLE_KEYS list (see src/config/util/nullable_keys.py)
+        #   then it is allowed to be blank, it counts as a valid entry
+        if key_value == "" and key_name in NULLABLE_KEYS:
+            self.project_logger.log_debug(
+                "The key '" + key_name + "' has an empty value; because it is an optional key, this is still valid"
+            )
+            # Stop the function here; do not try to validate this key
+            return True
 
         def make_message(message):
             return 'Input variable "' + key_name + '" points to "' + key_value + '", which ' + message

--- a/src/config/validation/test_key_validation.py
+++ b/src/config/validation/test_key_validation.py
@@ -88,6 +88,11 @@ class TestValidator(unittest.TestCase):
         result = self.validator.check_key("key_of_unknown_type", "KeyValue", key_type="UnacceptableType")
         self.assertFalse(result)
 
+    def test_check_key_nullable_type_with_empty_value(self):
+        # InputRead2 is listed as a nullable (or optional) key in src/config/util/nullable_keys.py, so it can be empty
+        result = self.validator.check_key("InputRead2", "", key_type="File")
+        self.assertTrue(result)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/config/validation/test_resources/test_config.json
+++ b/src/config/validation/test_resources/test_config.json
@@ -2,6 +2,7 @@
   "major_name.minor_name.test_string": "This is just a string; no validation can be done",
   "major_name.minor_name.test_boolean": "true",
   "major_name.minor_name.test_integer": "7",
-  "major_name.minor_name.test_decimal": "3.14159"
+  "major_name.minor_name.test_decimal": "3.14159",
+  "major_name.minor_name.DebugMode": ""
 
 }

--- a/src/config/validation/test_resources/test_key_types.json
+++ b/src/config/validation/test_resources/test_key_types.json
@@ -2,5 +2,6 @@
   "test_string": "String",
   "test_integer": "Integer",
   "test_decimal": "Decimal",
-  "test_boolean": "Boolean"
+  "test_boolean": "Boolean",
+  "DebugMode": "String"
 }

--- a/src/config/validation/test_resources/test_key_types.json
+++ b/src/config/validation/test_resources/test_key_types.json
@@ -3,5 +3,5 @@
   "test_integer": "Integer",
   "test_decimal": "Decimal",
   "test_boolean": "Boolean",
-  "DebugMode": "String"
+  "DebugMode": "DebugMode"
 }


### PR DESCRIPTION
Added ability to handle optional values
--------------------
IMPORTANT NOTE:
We must make sure that the Cromwell/WDL and the bash scripts will work with empty values in the optional variables (DebugMode and InputRead2) in the JSON file before merging to master
------------------
Added a list (src/config/util/nullable_keys.NULLABLE_KEYS) that contains the keys that are allowed to have empty strings as values (i.e. are "nullable"), and made adjustments to the parser and validator to accept these optional keys.

1. The parser will still throw an ERROR if a key not in the NULLABLE_KEYS list has no value
2. Empty values in the flat config file can either be blank ('OptionalKey=') or just have two double quotes ('OptionalKey=""'); it makes no difference
3. The validator will validate the values of optional keys if something is provided (i.e. it will check to see if "InputRead2" is a file), but will skip validation if an optional key has an empty string as its value
4. Added a special check for the "DebugMode" key, since its only acceptable values are either "-d" or an empty string
5. Even if an optional value is "off", its key still needs to be present in the flat config file to prevent Cromwell/WDL from failing because that key is not in the input JSON file (e.g. even if DebugMode is off, the config file still needs a line with 'DebugMode=' or 'DebugMode=""')
6. Previously, we allowed "optional values" to have a "NULL" string as their value, and their was a check for this in the validator. Because we now have optional values that can have empty strings, this check for a "NULL" string as a value was removed.