### PR TITLE
Add haplotyper option string

### DIFF
--- a/src/wdl_scripts/DesignBlock_2a/Tasks/haplotyper.wdl
+++ b/src/wdl_scripts/DesignBlock_2a/Tasks/haplotyper.wdl
@@ -9,6 +9,7 @@
 #               -D        "DBSNP File"                                            (Required)
 #               -s        "Name of the sample"                                    (Optional)
 #               -r        "Recal Data Table"                                      (Required)
+#               -o        "Haplotyper Extra Options"                              (Required)
 #               -S        "Path to the Sentieon Tool"                             (Required)
 #               -e        "Path to the environmental profile                      (Required)
 #               -d        "debug mode on/off                        (Optional: can be empty)
@@ -27,6 +28,8 @@ task variantCallingTask {
 
    String SampleName                                       # Name of the Sample
 
+   String HaplotyperExtraOptions                         # String of extra options for haplotyper, this can be an empty string
+
    File DBSNP                                              # DBSNP file
    File DBSNPIdx                                           # Index file for the DBSNPs   
   
@@ -42,7 +45,7 @@ task variantCallingTask {
 
    command {
 
-      /bin/bash ${HaplotyperScript} -s ${SampleName} -S ${Sentieon} -G ${Ref} -t ${SentieonThreads} -b ${InputAlignedSortedDedupedRealignedBam} -D ${DBSNP} -r ${RecalTable} -e ${HaplotyperEnvProfile} ${DebugMode}
+      /bin/bash ${HaplotyperScript} -s ${SampleName} -S ${Sentieon} -G ${Ref} -t ${SentieonThreads} -b ${InputAlignedSortedDedupedRealignedBam} -D ${DBSNP} -r ${RecalTable} -o ${HaplotyperExtraOptions} -e ${HaplotyperEnvProfile} ${DebugMode}
 
    }
 

--- a/src/wdl_scripts/DesignBlock_2a/Workflow/DesignBlock2a_ForWorkflow.wdl
+++ b/src/wdl_scripts/DesignBlock_2a/Workflow/DesignBlock2a_ForWorkflow.wdl
@@ -42,6 +42,8 @@ workflow CallBlock2aTasks {
    File HaplotyperScript
    File HaplotyperEnvProfile
 
+   String HaplotyperExtraOptions
+
    File VqsrScript
    File VqsrEnvProfile
 
@@ -92,7 +94,8 @@ workflow CallBlock2aTasks {
          Sentieon = Sentieon,
          DebugMode = DebugMode,
          HaplotyperScript = HaplotyperScript,
-         HaplotyperEnvProfile = HaplotyperEnvProfile
+         HaplotyperEnvProfile = HaplotyperEnvProfile,
+	 HaplotyperExtraOptions = HaplotyperExtraOptions
    }
 
    call VQSR.vqsrTask as vqsr {


### PR DESCRIPTION
I added an option -o for the Haplotyper.sh, which is a list of extra input options as a string. Its similar to what we did with the VQSR script with resource and annotation strings. I tested the bash script separately, and the WDL scripts for the 2a workflow. 

