### PR TITLE
Added traps to every wdl command block for killed cluster jobs

### DIFF
--- a/src/wdl_scripts/Alignment/Tasks/alignment.wdl
+++ b/src/wdl_scripts/Alignment/Tasks/alignment.wdl
@@ -44,18 +44,36 @@ task alignmentTask {
 
    String DebugMode                # Flag to enable Debug Mode
 
-   command {
+   command <<<
+      set -euxo pipefail
+
+      function sigusrhandler1()
+      {
+        echo "SIGUSR1 caught by shell script" 1>&2
+        echo 30 > ./rc
+        sync
+      }
+
+      function sigusrhandler2()
+      {
+        echo "SIGUSR2 caught by shell script" 1>&2
+              echo 31 > ./rc
+              sync
+      }
+
+      trap sigusrhandler1 SIGUSR1
+      trap sigusrhandler2 SIGUSR2
+
+      export LD_LIBRARY_PATH=""
 
       /bin/bash ${AlignmentScript} -P ${PairedEnd} -g ${Group} -l ${InputRead1} -r ${InputRead2} -s ${SampleName} -p ${Platform} -G ${Ref} -o ${BWAExtraOptionsString} -K ${ChunkSizeInBases} -S ${Sentieon} -t ${SentieonThreads} -e ${AlignEnvProfile} ${DebugMode}
 
-   }
+   >>>
 
    output {
 
       File OutputBams = "${SampleName}.aligned.sorted.bam"
       File OutputBais = "${SampleName}.aligned.sorted.bam.bai"
-
    }
-
-} 
+}
 

--- a/src/wdl_scripts/Alignment/Tasks/dedup.wdl
+++ b/src/wdl_scripts/Alignment/Tasks/dedup.wdl
@@ -28,11 +28,31 @@ task dedupTask {
    File DedupScript                       # Bash script that is called inside the WDL script
    File DedupEnvProfile                   # File containing the environmental profile variables
 
-   command {
+    command <<<
+    set -euxo pipefail
 
-      /bin/bash ${DedupScript} -b ${sep=',' InputBams} -s ${SampleName} -S ${Sentieon} -t ${SentieonThreads} -e ${DedupEnvProfile} ${DebugMode}
+    function sigusrhandler1()
+    {
+        echo "SIGUSR1 caught by shell script" 1>&2
+        echo 30 > ./rc
+        sync
+    }
 
-   }
+    function sigusrhandler2()
+    {
+        echo "SIGUSR2 caught by shell script" 1>&2
+        echo 31 > ./rc
+        sync
+    }
+
+    trap sigusrhandler1 SIGUSR1
+    trap sigusrhandler2 SIGUSR2
+
+
+    export LD_LIBRARY_PATH=""
+    /bin/bash ${DedupScript} -b ${sep=',' InputBams} -s ${SampleName} -S ${Sentieon} -t ${SentieonThreads} -e ${DedupEnvProfile} ${DebugMode}
+
+   >>>
 
    output {
 

--- a/src/wdl_scripts/Alignment/Tasks/trim_sequences.wdl
+++ b/src/wdl_scripts/Alignment/Tasks/trim_sequences.wdl
@@ -35,9 +35,31 @@ task trimsequencesTask {
    String DebugMode                # Variable to check if Debug Mode is on or not
 
 
-   command {
-      /bin/bash ${TrimSeqScript} -P ${PairedEnd} -l ${InputRead1} -r ${InputRead2} -s ${SampleName} -A ${Adapters} -C ${CutAdapt} -t ${CutAdaptThreads} -e ${TrimEnvProfile} ${DebugMode}
-   }
+   command <<<
+    set -euxo pipefail
+
+    function sigusrhandler1()
+    {
+       echo "SIGUSR1 caught by shell script" 1>&2
+       echo 30 > ./rc
+       sync
+    }
+
+    function sigusrhandler2()
+    {
+       echo "SIGUSR2 caught by shell script" 1>&2
+       echo 31 > ./rc
+       sync
+    }
+
+
+    trap sigusrhandler1 SIGUSR1
+    trap sigusrhandler2 SIGUSR2
+
+    export LD_LIBRARY_PATH=""
+    /bin/bash ${TrimSeqScript} -P ${PairedEnd} -l ${InputRead1} -r ${InputRead2} -s ${SampleName} -A ${Adapters} -C ${CutAdapt} -t ${CutAdaptThreads} -e ${TrimEnvProfile} ${DebugMode}
+
+   >>>
 
 
    output {

--- a/src/wdl_scripts/HaplotyperVC/Tasks/bqsr.wdl
+++ b/src/wdl_scripts/HaplotyperVC/Tasks/bqsr.wdl
@@ -38,9 +38,25 @@ task bqsrTask {
    String DebugMode                      # Enable or Disable Debug Mode
 
 
-   command {
-      /bin/bash ${BqsrScript} -s ${SampleName} -S ${Sentieon} -G ${Ref} -t ${SentieonThreads} -b ${InputBams} -k ${BqsrKnownSites} -e ${BqsrEnvProfile} ${DebugMode}
+   command <<<
+   set -euxo pipefail
+
+   function sigusrhandler1()
+   {
+       echo "SIGUSR1 caught by shell script" 1>&2
+       echo 30 > ./rc
+       sync
    }
+
+   function sigusrhandler2()
+   {
+       echo "SIGUSR2 caught by shell script" 1>&2
+       echo 31 > ./rc
+       sync
+   }
+
+   /bin/bash ${BqsrScript} -s ${SampleName} -S ${Sentieon} -G ${Ref} -t ${SentieonThreads} -b ${InputBams} -k ${BqsrKnownSites} -e ${BqsrEnvProfile} ${DebugMode}
+   >>>
 
    
    output {

--- a/src/wdl_scripts/HaplotyperVC/Tasks/haplotyper.wdl
+++ b/src/wdl_scripts/HaplotyperVC/Tasks/haplotyper.wdl
@@ -43,11 +43,30 @@ task variantCallingTask {
    String DebugMode                               # Enable or Disable Debug Mode
 
 
-   command {
+   command <<<
+    set -euxo pipefail
+
+        function sigusrhandler1()
+        {
+           echo "SIGUSR1 caught by shell script" 1>&2
+           echo 30 > ./rc
+           sync
+        }
+
+        function sigusrhandler2()
+        {
+           echo "SIGUSR2 caught by shell script" 1>&2
+           echo 31 > ./rc
+           sync
+        }
+
+
+        trap sigusrhandler1 SIGUSR1
+        trap sigusrhandler2 SIGUSR2
 
       /bin/bash ${HaplotyperScript} -s ${SampleName} -S ${Sentieon} -G ${Ref} -t ${SentieonThreads} -b ${InputBams} -D ${DBSNP} -r ${RecalTable} -o ${HaplotyperExtraOptionsString} -e ${HaplotyperEnvProfile} ${DebugMode}
 
-   }
+  >>>
 
   output {
    

--- a/src/wdl_scripts/HaplotyperVC/Tasks/realignment.wdl
+++ b/src/wdl_scripts/HaplotyperVC/Tasks/realignment.wdl
@@ -36,9 +36,29 @@ task realignmentTask {
 
  
 
-   command {
+   command <<<
+    set -euxo pipefail
+
+    function sigusrhandler1()
+    {
+       echo "SIGUSR1 caught by shell script" 1>&2
+       echo 30 > ./rc
+       sync
+    }
+
+    function sigusrhandler2()
+    {
+       echo "SIGUSR2 caught by shell script" 1>&2
+       echo 31 > ./rc
+       sync
+    }
+
+
+    trap sigusrhandler1 SIGUSR1
+    trap sigusrhandler2 SIGUSR2
+
       /bin/bash ${RealignmentScript} -s ${SampleName} -b ${InputBams} -G ${Ref} -k ${RealignmentKnownSites} -S ${Sentieon} -t ${SentieonThreads} -e ${RealignEnvProfile} ${DebugMode}
-   }
+   >>>
 
    output {
       File OutputBams = "${SampleName}.aligned.sorted.deduped.realigned.bam"

--- a/src/wdl_scripts/HaplotyperVC/Tasks/vqsr.wdl
+++ b/src/wdl_scripts/HaplotyperVC/Tasks/vqsr.wdl
@@ -42,11 +42,31 @@ task vqsrTask {
    String DebugMode                     # Enable or Disable Debug Mode
 
 
-   command {
-      /bin/bash ${VqsrScript} -s ${SampleName} -S ${Sentieon} -G ${Ref} -t ${SentieonThreads} -V ${InputVcf} -r ${VqsrSnpResourceString} -R ${VqsrIndelResourceString} -a ${AnnotateText} -e ${VqsrEnvProfile} ${DebugMode}
-   }
+   command <<<
+    set -euxo pipefail
 
-   
+    function sigusrhandler1()
+    {
+       echo "SIGUSR1 caught by shell script" 1>&2
+       echo 30 > ./rc
+       sync
+    }
+
+    function sigusrhandler2()
+    {
+       echo "SIGUSR2 caught by shell script" 1>&2
+       echo 31 > ./rc
+       sync
+    }
+
+
+    trap sigusrhandler1 SIGUSR1
+    trap sigusrhandler2 SIGUSR2
+
+
+      /bin/bash ${VqsrScript} -s ${SampleName} -S ${Sentieon} -G ${Ref} -t ${SentieonThreads} -V ${InputVcf} -r ${VqsrSnpResourceString} -R ${VqsrIndelResourceString} -a ${AnnotateText} -e ${VqsrEnvProfile} ${DebugMode}
+   >>>
+
    output {
       File OutputVcf = "${SampleName}.INDEL.SNP.recaled.vcf"
       File OutputVcfIdx = "${SampleName}.INDEL.SNP.recaled.vcf.idx"


### PR DESCRIPTION
This adds two traps to catch SIGUSR1 and SIGUSR2 signals and create the RC file with a non-zero exit code to notify the cromwell master process that a grid engine job is being terminated. 

It also sets Bash strict options to catch unset variable problems. 

The LD_LIBRARY_PATH setting is there to fix an issue with pkg profiles not using bash advanced variable expansions and unset paths.  